### PR TITLE
Update to HPy d5c8442b.

### DIFF
--- a/bench/bench_cpy_vs_hpy.py
+++ b/bench/bench_cpy_vs_hpy.py
@@ -1,0 +1,83 @@
+import time
+import numpy as np
+from math import pi, cos, sin
+
+def runge_kutta_step(mod, f, x0, dt, t=None):
+    k1 = f(mod, t, x0) * dt
+    k2 = f(mod, t, x0 + k1 / 2) * dt
+    k3 = f(mod, t, x0 + k2 / 2) * dt
+    k4 = f(mod, t, x0 + k3) * dt
+    x_new = x0 + (k1 + 2 * k2 + 2 * k3 + k4) / 6
+    return x_new
+
+
+def board(mod,t, X_0):
+    x0 = X_0[0]
+    y0 = X_0[1]
+    u0 = X_0[2]
+    v0 = X_0[3]
+
+    g = 9.81
+    c = 0.5
+    a = 0.25
+    b = 0.5
+    p = (2 * pi) / 10.0
+    q = (2 * pi) / 4.0
+
+    H_x = -a + b * p * sin(p * x0) * cos(q * y0)
+    H_xx = b * p ** 2 * cos(p * x0) * cos(q * y0)
+    H_y = b * q * cos(p * x0) * sin(q * y0)
+    H_yy = b * q ** 2 * cos(p * x0) * cos(q * y0)
+    H_xy = -b * q * p * sin(p * x0) * sin(q * y0)
+
+    F = (g + H_xx * u0 ** 2 + 2 * H_xy * u0 * v0 + H_yy * v0 ** 2) / (
+        1 + H_x ** 2 + H_y ** 2
+    )
+
+    dU = -F * H_x - c * u0
+    dV = -F * H_y - c * v0
+
+    return mod.array([u0, v0, dU, dV])
+
+
+def solver(mod, f, x0, y0, u0, v0, dt, N_t, b=0.5):
+    x0 = mod.array(x0.tolist())
+    y0 = mod.array(y0.tolist())
+    u0 = mod.array(u0.tolist())
+    v0 = mod.array(v0.tolist())
+
+    solutions = []
+    for k in range(len(x0)):
+        values_one_step = mod.array([x0[k], y0[k], u0[k], v0[k]])
+        for _ in range(N_t):
+            values_one_step = runge_kutta_step(mod, f, values_one_step, dt, b)
+        solutions.append(values_one_step)
+    return solutions
+
+
+def bench(mod, n_sleds, n_time):
+    x_init = np.zeros(n_sleds)
+    y_init = np.random.rand(n_sleds)
+    v_init = np.zeros(n_sleds)
+    u_init = np.zeros(n_sleds) + 3.5
+    start = time.time()
+    solver(mod, board, x_init, y_init, u_init, v_init, 0.01, n_time)
+    end = time.time()
+    return end-start
+
+N_SLEDS = 100
+N_TIME = 2000
+
+def main():
+    import piconumpy._piconumpy_cpython_capi as pnp_capi
+    import piconumpy._piconumpy_hpy as pnp_hpy
+
+    t = bench(pnp_capi, N_SLEDS, N_TIME)
+    print(f'CPython C-API: {t:.2f} seconds')
+    t = bench(pnp_hpy, N_SLEDS, N_TIME)
+    print(f'HPy:           {t:.2f} seconds')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/bench/bench_cpy_vs_hpy.py
+++ b/bench/bench_cpy_vs_hpy.py
@@ -73,15 +73,16 @@ def bench(mod, n_sleds, n_time):
     end = time.time()
     return end-start
 
+
 N_SLEDS = 100
 N_TIME = 2000
 
+
 def import_piconumpy_hpy_universal():
     import hpy.universal
-    class spec:
-        name = '_piconumpy_hpy'
-        origin = 'piconumpy/_piconumpy_hpy.hpy.so'
-    return hpy.universal.load_from_spec(spec)
+    return hpy.universal.load(
+        '_piconumpy_hpy', 'piconumpy/_piconumpy_hpy.hpy.so')
+
 
 def main():
 
@@ -99,7 +100,5 @@ def main():
         print(f'HPy [CPy ABI]:   {t:.2f} seconds')
 
 
-
 if __name__ == '__main__':
     main()
-

--- a/bench/bench_cpy_vs_hpy.py
+++ b/bench/bench_cpy_vs_hpy.py
@@ -1,6 +1,12 @@
 import time
-import numpy as np
+import random
 from math import pi, cos, sin
+
+def my_randn(mod, n):
+    result = mod.empty(n)
+    for i in range(n):
+        result[i] = random.normalvariate(0, 1)
+    return result
 
 def runge_kutta_step(mod, f, x0, dt, t=None):
     k1 = f(mod, t, x0) * dt
@@ -41,11 +47,6 @@ def board(mod,t, X_0):
 
 
 def solver(mod, f, x0, y0, u0, v0, dt, N_t, b=0.5):
-    x0 = mod.array(x0.tolist())
-    y0 = mod.array(y0.tolist())
-    u0 = mod.array(u0.tolist())
-    v0 = mod.array(v0.tolist())
-
     solutions = []
     for k in range(len(x0)):
         values_one_step = mod.array([x0[k], y0[k], u0[k], v0[k]])
@@ -56,10 +57,12 @@ def solver(mod, f, x0, y0, u0, v0, dt, N_t, b=0.5):
 
 
 def bench(mod, n_sleds, n_time):
-    x_init = np.zeros(n_sleds)
-    y_init = np.random.rand(n_sleds)
-    v_init = np.zeros(n_sleds)
-    u_init = np.zeros(n_sleds) + 3.5
+    x_init = mod.zeros(n_sleds)
+    y_init = my_randn(mod, n_sleds)
+    v_init = mod.zeros(n_sleds)
+    u_init = mod.zeros(n_sleds)
+    for i in range(n_sleds):
+        u_init[i] += 3.5
     start = time.time()
     solver(mod, board, x_init, y_init, u_init, v_init, 0.01, n_time)
     end = time.time()

--- a/bench/bench_cpy_vs_hpy.py
+++ b/bench/bench_cpy_vs_hpy.py
@@ -10,7 +10,9 @@ def runge_kutta_step(mod, f, x0, dt, t=None):
     k2 = f(mod, t, x0 + k1 / 2) * dt
     k3 = f(mod, t, x0 + k2 / 2) * dt
     k4 = f(mod, t, x0 + k3) * dt
-    x_new = x0 + (k1 + 2 * k2 + 2 * k3 + k4) / 6
+    # workaround for a pypy bug
+    #x_new = x0 + (k1 + 2 * k2 + 2 * k3 + k4) / 6
+    x_new = x0 + (k1 + (k2 * 2) + (k3 * 2) + k4) / 6
     return x_new
 
 

--- a/piconumpy/_piconumpy_cpython_capi.c
+++ b/piconumpy/_piconumpy_cpython_capi.c
@@ -128,13 +128,25 @@ Py_ssize_t Array_length(ArrayObject *arr) {
 };
 
 PyObject *Array_item(ArrayObject *arr, Py_ssize_t index) {
-  PyObject *item = NULL;
   if (index < 0 || index >= arr->size) {
-    return item;
+      PyErr_SetString(PyExc_IndexError, "index out of range");
+      return NULL;
   }
-  item = PyFloat_FromDouble(arr->data[index]);
-  return item;
+  return PyFloat_FromDouble(arr->data[index]);
 };
+
+int Array_setitem(ArrayObject *arr, Py_ssize_t index, PyObject *item) {
+    if (index < 0 || index >= arr->size) {
+        PyErr_SetString(PyExc_IndexError, "index out of range");
+        return -1;
+    }
+    double value = PyFloat_AsDouble(item);
+    if (PyErr_Occurred())
+        return -1;
+    arr->data[index] = value;
+    return 0;
+}
+
 
 static PyMethodDef Array_methods[] = {
     {"tolist", (PyCFunction)Array_tolist, METH_NOARGS,
@@ -153,6 +165,7 @@ static PyType_Slot Array_type_slots[] = {
     {Py_nb_true_divide, (binaryfunc)Array_divide},
     {Py_sq_length, (lenfunc)Array_length},
     {Py_sq_item, (ssizeargfunc)Array_item},
+    {Py_sq_ass_item, (ssizeobjargproc)Array_setitem},
     {0, NULL},
 };
 

--- a/piconumpy/_piconumpy_cpython_capi.c
+++ b/piconumpy/_piconumpy_cpython_capi.c
@@ -31,8 +31,10 @@ static int Array_init(ArrayObject *self, PyObject *args, PyObject *kwds) {
   self->size = (int)PyList_Size(data);
 
   self->data = (double *)malloc(self->size * sizeof(double));
-  if (self->data == NULL)
-    return PyErr_NoMemory();
+  if (self->data == NULL) {
+    PyErr_NoMemory();
+    return -1;
+  }
 
   for (index = 0; index < self->size; index++) {
     item = PyList_GET_ITEM(data, index);
@@ -63,15 +65,15 @@ static ArrayObject *Array_empty(int size);
 static ArrayObject *Array_multiply(PyObject *o1, PyObject *o2) {
   int index;
   double number;
-  PyObject *obj_number;
-  ArrayObject *result = NULL, *arr;
+  PyObject *obj_number = NULL;
+  ArrayObject *result = NULL, *arr = NULL;
 
   if (PyNumber_Check(o2)) {
     obj_number = o2;
-    arr = o1;
+    arr = (ArrayObject *)o1;
   } else if (PyNumber_Check(o1)) {
     obj_number = o1;
-    arr = o2;
+    arr = (ArrayObject *)o2;
   }
 
   if (PyNumber_Check(o1) | PyNumber_Check(o2)) {
@@ -88,8 +90,8 @@ static ArrayObject *Array_multiply(PyObject *o1, PyObject *o2) {
 static ArrayObject *Array_add(PyObject *o1, PyObject *o2) {
   int index;
   ArrayObject *result = NULL, *a1, *a2;
-  a1 = o1;
-  a2 = o2;
+  a1 = (ArrayObject *)o1;
+  a2 = (ArrayObject *)o2;
 
   if (a1->size != a2->size)
     return result;
@@ -110,7 +112,7 @@ static ArrayObject *Array_divide(PyObject *o1, PyObject *o2) {
   if (!PyNumber_Check(o2)) {
     return result;
   }
-  a1 = o1;
+  a1 = (ArrayObject *)o1;
   number = PyFloat_AsDouble(o2);
   result = Array_empty(a1->size);
   for (index = 0; index < a1->size; index++) {
@@ -125,9 +127,9 @@ Py_ssize_t Array_length(ArrayObject *arr) {
   return result;
 };
 
-PyFloatObject *Array_item(ArrayObject *arr, Py_ssize_t index) {
-  PyFloatObject *item = NULL;
-  if (index < 0 | index >= arr->size) {
+PyObject *Array_item(ArrayObject *arr, Py_ssize_t index) {
+  PyObject *item = NULL;
+  if (index < 0 || index >= arr->size) {
     return item;
   }
   item = PyFloat_FromDouble(arr->data[index]);
@@ -140,7 +142,7 @@ static PyMethodDef Array_methods[] = {
     {NULL} /* Sentinel */
 };
 
-static const PyType_Slot Array_type_slots[] = {
+static PyType_Slot Array_type_slots[] = {
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_init, (initproc)Array_init},
     {Py_tp_dealloc, (destructor)Array_dealloc},
@@ -154,7 +156,7 @@ static const PyType_Slot Array_type_slots[] = {
     {0, NULL},
 };
 
-static const PyType_Spec Array_type_spec = {
+static PyType_Spec Array_type_spec = {
     .name = "_piconumpy_cpython_capi.array",
     .basicsize = sizeof(ArrayObject),
     .itemsize = 0,
@@ -169,8 +171,10 @@ static ArrayObject *Array_empty(int size) {
   new_array = PyObject_New(ArrayObject, ptr_ArrayType);
   new_array->size = size;
   new_array->data = (double *)malloc(size * sizeof(double));
-  if (new_array->data == NULL)
-    return PyErr_NoMemory();
+  if (new_array->data == NULL) {
+     PyErr_NoMemory();
+     return NULL;
+  }
   return new_array;
 };
 

--- a/piconumpy/_piconumpy_cpython_capi.c
+++ b/piconumpy/_piconumpy_cpython_capi.c
@@ -193,13 +193,11 @@ static PyModuleDef piconumpymodule = {
 PyMODINIT_FUNC PyInit__piconumpy_cpython_capi(void) {
   PyObject *m;
 
-  ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
-
   m = PyModule_Create(&piconumpymodule);
   if (m == NULL)
     return NULL;
 
-  Py_INCREF(ptr_ArrayType);
+  ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
   if (PyModule_AddObject(m, "array", (PyObject *)ptr_ArrayType) < 0) {
     Py_DECREF(ptr_ArrayType);
     Py_DECREF(m);

--- a/piconumpy/_piconumpy_cpython_capi.c
+++ b/piconumpy/_piconumpy_cpython_capi.c
@@ -184,8 +184,19 @@ static ArrayObject *empty(PyObject *module, PyObject *arg) {
   return Array_empty(size);
 };
 
+static ArrayObject *zeros(PyObject *module, PyObject *arg) {
+  int size;
+  size = (int)PyLong_AsLong(arg);
+  ArrayObject *result = Array_empty(size);
+  for(int i=0; i<size; i++)
+      result->data[i] = 0;
+  return result;
+};
+
+
 static PyMethodDef module_methods[] = {
     {"empty", (PyCFunction)empty, METH_O, "Create an empty array."},
+    {"zeros", (PyCFunction)zeros, METH_O, "Createa zero-filled array."},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 

--- a/piconumpy/_piconumpy_cython.pyx
+++ b/piconumpy/_piconumpy_cython.pyx
@@ -53,3 +53,6 @@ class array:
 
     def __getitem__(self, index):
         return self.data[index]
+
+cpdef empty(size):
+    return array([0]*size)

--- a/piconumpy/_piconumpy_cython.pyx
+++ b/piconumpy/_piconumpy_cython.pyx
@@ -56,3 +56,6 @@ class array:
 
 cpdef empty(size):
     return array([0]*size)
+
+cpdef zeros(size):
+    return array([0]*size)

--- a/piconumpy/_piconumpy_cython.pyx
+++ b/piconumpy/_piconumpy_cython.pyx
@@ -54,6 +54,9 @@ class array:
     def __getitem__(self, index):
         return self.data[index]
 
+    def __setitem__(self, index, value):
+        self.data[index] = value
+
 cpdef empty(size):
     return array([0]*size)
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -157,15 +157,16 @@ static PyType_Slot Array_type_slots[] = {
     {0, NULL},
 };
 
-static PyType_Spec Array_type_spec = {
+static HPyType_Spec Array_type_spec = {
     .name = "_piconumpy_hpy.array",
     .basicsize = sizeof(ArrayObject),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT,
-    .slots = Array_type_slots,
+    .flags = HPy_TPFLAGS_DEFAULT,
+    .legacy_slots = Array_type_slots,
 };
 
 PyTypeObject *ptr_ArrayType;
+HPy h_ArrayType;
 
 static ArrayObject *Array_empty(int size) {
   ArrayObject *new_array = NULL;
@@ -210,12 +211,14 @@ static HPy init__piconumpy_hpy_impl(HPyContext ctx) {
   if (HPy_IsNull(hm))
     return HPy_NULL;
 
-  ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
-  HPy h_ArrayType = HPy_FromPyObject(ctx, (PyObject *)ptr_ArrayType);
-  Py_DECREF(ptr_ArrayType);
+  h_ArrayType = HPyType_FromSpec(ctx, &Array_type_spec);
+  if (HPy_IsNull(h_ArrayType))
+      return HPy_NULL;
+  ptr_ArrayType = (PyTypeObject *)HPy_AsPyObject(ctx, h_ArrayType);
 
   if (HPy_SetAttr_s(ctx, hm, "array", h_ArrayType) < 0) {
     HPy_Close(ctx, h_ArrayType);
+    Py_DECREF(ptr_ArrayType);
     HPy_Close(ctx, hm);
     return HPy_NULL;
   }

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -200,9 +200,24 @@ static HPy empty_impl(HPyContext ctx, HPy module, HPy arg) {
   return Array_empty(ctx, size, &result);
 };
 
+/* XXX add the docstring: "Create a zero-filled array" */
+HPyDef_METH(zeros, "zeros", zeros_impl, HPyFunc_O)
+static HPy zeros_impl(HPyContext ctx, HPy module, HPy arg) {
+  int size;
+  ArrayObject *result;
+  size = (int)HPyLong_AsLong(ctx, arg);
+  HPy h_result = Array_empty(ctx, size, &result);
+  if (HPy_IsNull(h_result))
+      return HPy_NULL;
+  for(int i=0; i<size; i++)
+      result->data[i] = 0;
+  return h_result;
+};
+
 
 static HPyDef *module_defines[] = {
     &empty,
+    &zeros,
     NULL
 };
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -7,13 +7,13 @@ typedef struct {
   int size;
 } ArrayObject;
 
-HPyDef_SLOT(Array_destroy, HPy_tp_destroy, Array_destroy_impl, HPyFunc_DESTROYFUNC)
+HPyDef_SLOT(Array_destroy, Array_destroy_impl, HPy_tp_destroy)
 static void Array_destroy_impl(void *obj) {
   ArrayObject *self = (ArrayObject *)obj;
   free(self->data);
 }
 
-HPyDef_SLOT(Array_init, HPy_tp_init, Array_init_impl, HPyFunc_INITPROC)
+HPyDef_SLOT(Array_init, Array_init_impl, HPy_tp_init)
 static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
                            HPy_ssize_t nargs, HPy kw) {
   static const char *kwlist[] = {"data", NULL};
@@ -67,8 +67,7 @@ static HPy Array_tolist_impl(HPyContext ctx, HPy h_self) {
 
 static HPy Array_empty(HPyContext ctx, int size, ArrayObject **result);
 
-HPyDef_SLOT(Array_multiply, HPy_nb_multiply, Array_multiply_impl,
-            HPyFunc_BINARYFUNC)
+HPyDef_SLOT(Array_multiply, Array_multiply_impl, HPy_nb_multiply)
 static HPy Array_multiply_impl(HPyContext ctx, HPy h1, HPy h2) {
   int index;
   double number;
@@ -95,7 +94,7 @@ static HPy Array_multiply_impl(HPyContext ctx, HPy h1, HPy h2) {
   return h_result;
 };
 
-HPyDef_SLOT(Array_add, HPy_nb_add, Array_add_impl, HPyFunc_BINARYFUNC)
+HPyDef_SLOT(Array_add, Array_add_impl, HPy_nb_add)
 static HPy Array_add_impl(HPyContext ctx, HPy h1, HPy h2) {
   int index;
   ArrayObject *result = NULL, *a1, *a2;
@@ -113,7 +112,7 @@ static HPy Array_add_impl(HPyContext ctx, HPy h1, HPy h2) {
   return h_result;
 };
 
-HPyDef_SLOT(Array_divide, HPy_nb_true_divide, Array_divide_impl, HPyFunc_BINARYFUNC)
+HPyDef_SLOT(Array_divide, Array_divide_impl, HPy_nb_true_divide)
 static HPy Array_divide_impl(HPyContext ctx, HPy h1, HPy h2) {
   int index;
   double number;
@@ -133,7 +132,7 @@ static HPy Array_divide_impl(HPyContext ctx, HPy h1, HPy h2) {
 };
 
 
-HPyDef_SLOT(Array_length, HPy_sq_length, Array_length_impl, HPyFunc_LENFUNC)
+HPyDef_SLOT(Array_length, Array_length_impl, HPy_sq_length)
 HPy_ssize_t Array_length_impl(HPyContext ctx, HPy h_arr) {
   ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
   HPy_ssize_t result = (HPy_ssize_t)arr->size;
@@ -141,7 +140,7 @@ HPy_ssize_t Array_length_impl(HPyContext ctx, HPy h_arr) {
 };
 
 
-HPyDef_SLOT(Array_item, HPy_sq_item, Array_item_impl, HPyFunc_SSIZEARGFUNC)
+HPyDef_SLOT(Array_item, Array_item_impl, HPy_sq_item)
 HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
   ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
   if (index < 0 || index >= arr->size) {
@@ -151,7 +150,7 @@ HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
   return item;
 };
 
-HPyDef_SLOT(Array_new, HPy_tp_new, HPyType_GenericNew, HPyFunc_KEYWORDS)
+HPyDef_SLOT(Array_new, HPyType_GenericNew, HPy_tp_new)
 
 static HPyDef *Array_defines[] = {
     // slots
@@ -221,7 +220,7 @@ static HPy init__piconumpy_hpy_impl(HPyContext ctx) {
   if (HPy_IsNull(hm))
     return HPy_NULL;
 
-  h_ArrayType = HPyType_FromSpec(ctx, &Array_type_spec);
+  h_ArrayType = HPyType_FromSpec(ctx, &Array_type_spec, NULL);
   if (HPy_IsNull(h_ArrayType))
       return HPy_NULL;
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -159,8 +159,10 @@ static PyMethodDef Array_methods[] = {
     {NULL} /* Sentinel */
 };
 
+
+HPyDef_SLOT(Array_new, HPy_tp_new, HPyType_GenericNew, HPyFunc_KEYWORDS)
+
 static PyType_Slot Array_type_slots[] = {
-    {Py_tp_new, PyType_GenericNew},
     {Py_tp_init, (initproc)Array_init},
     {Py_tp_dealloc, (destructor)Array_dealloc},
     {Py_tp_members, Array_members},
@@ -169,6 +171,7 @@ static PyType_Slot Array_type_slots[] = {
 };
 
 static HPyDef *Array_defines[] = {
+    &Array_new,
     &Array_add,
     &Array_multiply,
     &Array_divide,

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -175,15 +175,21 @@ static ArrayObject *Array_empty(int size) {
   return new_array;
 };
 
-static ArrayObject *empty(PyObject *module, PyObject *arg) {
+/* XXX add the docstring: "Create an empty array" */
+HPyDef_METH(empty, "empty", empty_impl, HPyFunc_O)
+static HPy empty_impl(HPyContext ctx, HPy module, HPy arg) {
   int size;
-  size = (int)PyLong_AsLong(arg);
-  return Array_empty(size);
+  size = (int)HPyLong_AsLong(ctx, arg);
+  PyObject *result = Array_empty(size);
+  HPy h_result = HPy_FromPyObject(ctx, result);
+  Py_DECREF(result);
+  return h_result;
 };
 
-static PyMethodDef legacy_methods[] = {
-    {"empty", (PyCFunction)empty, METH_O, "Create an empty array."},
-    {NULL, NULL, 0, NULL} /* Sentinel */
+
+static HPyDef *module_defines[] = {
+    &empty,
+    NULL
 };
 
 static HPyModuleDef piconumpymodule = {
@@ -191,7 +197,7 @@ static HPyModuleDef piconumpymodule = {
     .m_name = "_piconumpy_hpy",
     .m_doc = "piconumpy implemented with the HPy API.",
     .m_size = -1,
-    .legacy_methods = legacy_methods
+    .defines = module_defines,
 };
 
 HPy_MODINIT(_piconumpy_hpy)

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -51,8 +51,8 @@ static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
 HPyDef_MEMBER(Array_size, "size", HPyMember_INT, offsetof(ArrayObject, size),
               .doc = "size of the array")
 
-// XXX add the docstring: "Return the data as a list"
-HPyDef_METH(Array_tolist, "tolist", Array_tolist_impl, HPyFunc_NOARGS)
+HPyDef_METH(Array_tolist, "tolist", Array_tolist_impl, HPyFunc_NOARGS,
+            .doc = "Return the data as a list")
 static HPy Array_tolist_impl(HPyContext ctx, HPy h_self) {
   ArrayObject *self = HPy_CAST(ctx, ArrayObject, h_self);
   int index;
@@ -208,8 +208,7 @@ static HPy Array_empty(HPyContext ctx, int size, ArrayObject **result) {
   return h_new_array;
 };
 
-/* XXX add the docstring: "Create an empty array" */
-HPyDef_METH(empty, "empty", empty_impl, HPyFunc_O)
+HPyDef_METH(empty, "empty", empty_impl, HPyFunc_O, .doc = "Create an empty array")
 static HPy empty_impl(HPyContext ctx, HPy module, HPy arg) {
   int size;
   ArrayObject *result;
@@ -217,8 +216,7 @@ static HPy empty_impl(HPyContext ctx, HPy module, HPy arg) {
   return Array_empty(ctx, size, &result);
 };
 
-/* XXX add the docstring: "Create a zero-filled array" */
-HPyDef_METH(zeros, "zeros", zeros_impl, HPyFunc_O)
+HPyDef_METH(zeros, "zeros", zeros_impl, HPyFunc_O, .doc = "Create a zero-filled array")
 static HPy zeros_impl(HPyContext ctx, HPy module, HPy arg) {
   int size;
   ArrayObject *result;

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -189,7 +189,6 @@ static HPyType_Spec Array_type_spec = {
     .defines = Array_defines,
 };
 
-PyTypeObject *ptr_ArrayType;
 HPy h_ArrayType;
 
 static HPy Array_empty(HPyContext ctx, int size, ArrayObject **result) {
@@ -236,11 +235,9 @@ static HPy init__piconumpy_hpy_impl(HPyContext ctx) {
   h_ArrayType = HPyType_FromSpec(ctx, &Array_type_spec);
   if (HPy_IsNull(h_ArrayType))
       return HPy_NULL;
-  ptr_ArrayType = (PyTypeObject *)HPy_AsPyObject(ctx, h_ArrayType);
 
   if (HPy_SetAttr_s(ctx, hm, "array", h_ArrayType) < 0) {
     HPy_Close(ctx, h_ArrayType);
-    Py_DECREF(ptr_ArrayType);
     HPy_Close(ctx, hm);
     return HPy_NULL;
   }

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -1,0 +1,210 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "structmember.h"
+
+typedef struct {
+  PyObject_HEAD
+      /* Type-specific fields go here. */
+      double *data;
+  int size;
+} ArrayObject;
+
+static void Array_dealloc(ArrayObject *self) {
+  free(self->data);
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static int Array_init(ArrayObject *self, PyObject *args, PyObject *kwds) {
+  static char *kwlist[] = {"data", NULL};
+  int index;
+  PyObject *data = NULL, *item;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &data))
+    return -1;
+
+  if (!PyList_Check(data)) {
+    PyErr_SetString(PyExc_TypeError, "parameter must be a list");
+    return -1;
+  }
+
+  self->size = (int)PyList_Size(data);
+
+  self->data = (double *)malloc(self->size * sizeof(double));
+  if (self->data == NULL)
+    return PyErr_NoMemory();
+
+  for (index = 0; index < self->size; index++) {
+    item = PyList_GET_ITEM(data, index);
+    self->data[index] = PyFloat_AsDouble(item);
+  }
+
+  return 0;
+}
+
+static PyMemberDef Array_members[] = {
+    {"size", T_INT, offsetof(ArrayObject, size), 0, "size of the array"},
+    {NULL} /* Sentinel */
+};
+
+static PyObject *Array_tolist(ArrayObject *self, PyObject *Py_UNUSED(ignored)) {
+  int index;
+  PyObject *result, *item;
+  result = PyList_New(self->size);
+  for (index = 0; index < self->size; index++) {
+    item = PyFloat_FromDouble(self->data[index]);
+    PyList_SetItem(result, index, item);
+  }
+  return result;
+};
+
+static ArrayObject *Array_empty(int size);
+
+static ArrayObject *Array_multiply(PyObject *o1, PyObject *o2) {
+  int index;
+  double number;
+  PyObject *obj_number;
+  ArrayObject *result = NULL, *arr;
+
+  if (PyNumber_Check(o2)) {
+    obj_number = o2;
+    arr = o1;
+  } else if (PyNumber_Check(o1)) {
+    obj_number = o1;
+    arr = o2;
+  }
+
+  if (PyNumber_Check(o1) | PyNumber_Check(o2)) {
+    number = PyFloat_AsDouble(obj_number);
+    result = Array_empty(arr->size);
+    for (index = 0; index < arr->size; index++) {
+      result->data[index] = arr->data[index] * number;
+    }
+  }
+
+  return result;
+};
+
+static ArrayObject *Array_add(PyObject *o1, PyObject *o2) {
+  int index;
+  ArrayObject *result = NULL, *a1, *a2;
+  a1 = o1;
+  a2 = o2;
+
+  if (a1->size != a2->size)
+    return result;
+
+  result = Array_empty(a1->size);
+  for (index = 0; index < a1->size; index++) {
+    result->data[index] = a1->data[index] + a2->data[index];
+  }
+
+  return result;
+};
+
+static ArrayObject *Array_divide(PyObject *o1, PyObject *o2) {
+  int index;
+  double number;
+  ArrayObject *result = NULL, *a1;
+
+  if (!PyNumber_Check(o2)) {
+    return result;
+  }
+  a1 = o1;
+  number = PyFloat_AsDouble(o2);
+  result = Array_empty(a1->size);
+  for (index = 0; index < a1->size; index++) {
+    result->data[index] = a1->data[index] / number;
+  }
+
+  return result;
+};
+
+Py_ssize_t Array_length(ArrayObject *arr) {
+  Py_ssize_t result = (Py_ssize_t)arr->size;
+  return result;
+};
+
+PyFloatObject *Array_item(ArrayObject *arr, Py_ssize_t index) {
+  PyFloatObject *item = NULL;
+  if (index < 0 | index >= arr->size) {
+    return item;
+  }
+  item = PyFloat_FromDouble(arr->data[index]);
+  return item;
+};
+
+static PyMethodDef Array_methods[] = {
+    {"tolist", (PyCFunction)Array_tolist, METH_NOARGS,
+     "Return the data as a list"},
+    {NULL} /* Sentinel */
+};
+
+static const PyType_Slot Array_type_slots[] = {
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_init, (initproc)Array_init},
+    {Py_tp_dealloc, (destructor)Array_dealloc},
+    {Py_tp_members, Array_members},
+    {Py_tp_methods, Array_methods},
+    {Py_nb_multiply, (binaryfunc)Array_multiply},
+    {Py_nb_add, (binaryfunc)Array_add},
+    {Py_nb_true_divide, (binaryfunc)Array_divide},
+    {Py_sq_length, (lenfunc)Array_length},
+    {Py_sq_item, (ssizeargfunc)Array_item},
+    {0, NULL},
+};
+
+static const PyType_Spec Array_type_spec = {
+    .name = "_piconumpy_hpy.array",
+    .basicsize = sizeof(ArrayObject),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT,
+    .slots = Array_type_slots,
+};
+
+PyTypeObject *ptr_ArrayType;
+
+static ArrayObject *Array_empty(int size) {
+  ArrayObject *new_array = NULL;
+  new_array = PyObject_New(ArrayObject, ptr_ArrayType);
+  new_array->size = size;
+  new_array->data = (double *)malloc(size * sizeof(double));
+  if (new_array->data == NULL)
+    return PyErr_NoMemory();
+  return new_array;
+};
+
+static ArrayObject *empty(PyObject *module, PyObject *arg) {
+  int size;
+  size = (int)PyLong_AsLong(arg);
+  return Array_empty(size);
+};
+
+static PyMethodDef module_methods[] = {
+    {"empty", (PyCFunction)empty, METH_O, "Create an empty array."},
+    {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+static PyModuleDef piconumpymodule = {
+    PyModuleDef_HEAD_INIT, .m_name = "_piconumpy_hpy",
+    .m_doc = "piconumpy implemented with the HPy API.", .m_size = -1,
+    module_methods};
+
+PyMODINIT_FUNC PyInit__piconumpy_hpy(void) {
+  PyObject *m;
+
+  ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
+
+  m = PyModule_Create(&piconumpymodule);
+  if (m == NULL)
+    return NULL;
+
+  Py_INCREF(ptr_ArrayType);
+  if (PyModule_AddObject(m, "array", (PyObject *)ptr_ArrayType) < 0) {
+    Py_DECREF(ptr_ArrayType);
+    Py_DECREF(m);
+    return NULL;
+  }
+
+  return m;
+}

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -113,22 +113,25 @@ static HPy Array_add_impl(HPyContext ctx, HPy h1, HPy h2) {
   return h_result;
 };
 
-static ArrayObject *Array_divide(PyObject *o1, PyObject *o2) {
+HPyDef_SLOT(Array_divide, HPy_nb_true_divide, Array_divide_impl, HPyFunc_BINARYFUNC)
+static HPy Array_divide_impl(HPyContext ctx, HPy h1, HPy h2) {
   int index;
   double number;
   ArrayObject *result = NULL, *a1;
 
-  if (!PyNumber_Check(o2)) {
-    return result;
+  if (!HPyNumber_Check(ctx, h2)) {
+    return HPy_NULL;
   }
-  a1 = (ArrayObject *)o1;
-  number = PyFloat_AsDouble(o2);
+  a1 = HPy_CAST(ctx, ArrayObject, h1);
+  number = HPyFloat_AsDouble(ctx, h2);
   result = Array_empty(a1->size);
   for (index = 0; index < a1->size; index++) {
     result->data[index] = a1->data[index] / number;
   }
 
-  return result;
+  HPy h_result = HPy_FromPyObject(ctx, (PyObject *)result);
+  Py_DECREF(result);
+  return h_result;
 };
 
 
@@ -162,13 +165,13 @@ static PyType_Slot Array_type_slots[] = {
     {Py_tp_dealloc, (destructor)Array_dealloc},
     {Py_tp_members, Array_members},
     {Py_tp_methods, Array_methods},
-    {Py_nb_true_divide, (binaryfunc)Array_divide},
     {0, NULL},
 };
 
 static HPyDef *Array_defines[] = {
     &Array_add,
     &Array_multiply,
+    &Array_divide,
     &Array_item,
     &Array_length,
     NULL

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -1,7 +1,3 @@
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
-#include "structmember.h"
-
 #include "hpy.h"
 
 typedef struct {
@@ -52,10 +48,8 @@ static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
   return 0;
 }
 
-static PyMemberDef Array_members[] = {
-    {"size", T_INT, offsetof(ArrayObject, size), 0, "size of the array"},
-    {NULL} /* Sentinel */
-};
+HPyDef_MEMBER(Array_size, "size", HPyMember_INT, offsetof(ArrayObject, size),
+              .doc = "size of the array")
 
 // XXX add the docstring: "Return the data as a list"
 HPyDef_METH(Array_tolist, "tolist", Array_tolist_impl, HPyFunc_NOARGS)
@@ -157,13 +151,7 @@ HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
   return item;
 };
 
-
 HPyDef_SLOT(Array_new, HPy_tp_new, HPyType_GenericNew, HPyFunc_KEYWORDS)
-
-static PyType_Slot Array_type_slots[] = {
-    {Py_tp_members, Array_members},
-    {0, NULL},
-};
 
 static HPyDef *Array_defines[] = {
     // slots
@@ -175,6 +163,8 @@ static HPyDef *Array_defines[] = {
     &Array_divide,
     &Array_item,
     &Array_length,
+    // members
+    &Array_size,
     // methods
     &Array_tolist,
     NULL
@@ -185,7 +175,6 @@ static HPyType_Spec Array_type_spec = {
     .basicsize = sizeof(ArrayObject),
     .itemsize = 0,
     .flags = HPy_TPFLAGS_DEFAULT,
-    .legacy_slots = Array_type_slots,
     .defines = Array_defines,
 };
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -200,11 +200,12 @@ static HPy init__piconumpy_hpy_impl(HPyContext ctx) {
   if (HPy_IsNull(hm))
     return HPy_NULL;
 
-  PyObject *m = HPy_AsPyObject(ctx, hm);
   ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
-  if (PyModule_AddObject(m, "array", (PyObject *)ptr_ArrayType) < 0) {
-    Py_DECREF(ptr_ArrayType);
-    Py_DECREF(m);
+  HPy h_ArrayType = HPy_FromPyObject(ctx, ptr_ArrayType);
+  Py_DECREF(ptr_ArrayType);
+
+  if (HPy_SetAttr_s(ctx, hm, "array", h_ArrayType) < 0) {
+    HPy_Close(ctx, h_ArrayType);
     HPy_Close(ctx, hm);
     return HPy_NULL;
   }

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -144,11 +144,27 @@ HPyDef_SLOT(Array_item, Array_item_impl, HPy_sq_item)
 HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
   ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
   if (index < 0 || index >= arr->size) {
+    HPyErr_SetString(ctx, ctx->h_IndexError, "index out of range");
     return HPy_NULL;
   }
   HPy item = HPyFloat_FromDouble(ctx, arr->data[index]);
   return item;
 };
+
+HPyDef_SLOT(Array_setitem, Array_setitem_impl, HPy_sq_ass_item)
+int Array_setitem_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index, HPy h_item) {
+  ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
+  if (index < 0 || index >= arr->size) {
+    HPyErr_SetString(ctx, ctx->h_IndexError, "index out of range");
+    return -1;
+  }
+  double value = HPyFloat_AsDouble(ctx, h_item);
+  if (HPyErr_Occurred(ctx))
+    return -1;
+  arr->data[index] = value;
+  return 0;
+};
+
 
 HPyDef_SLOT(Array_new, HPyType_GenericNew, HPy_tp_new)
 
@@ -161,6 +177,7 @@ static HPyDef *Array_defines[] = {
     &Array_multiply,
     &Array_divide,
     &Array_item,
+    &Array_setitem,
     &Array_length,
     // members
     &Array_size,

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -57,15 +57,18 @@ static PyMemberDef Array_members[] = {
     {NULL} /* Sentinel */
 };
 
-static PyObject *Array_tolist(ArrayObject *self, PyObject *Py_UNUSED(ignored)) {
+// XXX add the docstring: "Return the data as a list"
+HPyDef_METH(Array_tolist, "tolist", Array_tolist_impl, HPyFunc_NOARGS)
+static HPy Array_tolist_impl(HPyContext ctx, HPy h_self) {
+  ArrayObject *self = HPy_CAST(ctx, ArrayObject, h_self);
   int index;
-  PyObject *result, *item;
-  result = PyList_New(self->size);
+  HPy h_result = HPyList_New(ctx, self->size);
   for (index = 0; index < self->size; index++) {
-    item = PyFloat_FromDouble(self->data[index]);
-    PyList_SetItem(result, index, item);
+    HPy h_item = HPyFloat_FromDouble(ctx, self->data[index]);
+    HPy_SetItem_i(ctx, h_result, index, h_item);
+    HPy_Close(ctx, h_item);
   }
-  return result;
+  return h_result;
 };
 
 static HPy Array_empty(HPyContext ctx, int size, ArrayObject **result);
@@ -154,22 +157,16 @@ HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
   return item;
 };
 
-static PyMethodDef Array_methods[] = {
-    {"tolist", (PyCFunction)Array_tolist, METH_NOARGS,
-     "Return the data as a list"},
-    {NULL} /* Sentinel */
-};
-
 
 HPyDef_SLOT(Array_new, HPy_tp_new, HPyType_GenericNew, HPyFunc_KEYWORDS)
 
 static PyType_Slot Array_type_slots[] = {
     {Py_tp_members, Array_members},
-    {Py_tp_methods, Array_methods},
     {0, NULL},
 };
 
 static HPyDef *Array_defines[] = {
+    // slots
     &Array_new,
     &Array_init,
     &Array_destroy,
@@ -178,6 +175,8 @@ static HPyDef *Array_defines[] = {
     &Array_divide,
     &Array_item,
     &Array_length,
+    // methods
+    &Array_tolist,
     NULL
 };
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -136,12 +136,14 @@ Py_ssize_t Array_length(ArrayObject *arr) {
   return result;
 };
 
-PyObject *Array_item(ArrayObject *arr, Py_ssize_t index) {
-  PyObject *item = NULL;
+
+HPyDef_SLOT(Array_item, HPy_sq_item, Array_item_impl, HPyFunc_SSIZEARGFUNC)
+HPy Array_item_impl(HPyContext ctx, HPy h_arr, HPy_ssize_t index) {
+  ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
   if (index < 0 || index >= arr->size) {
-    return item;
+    return HPy_NULL;
   }
-  item = PyFloat_FromDouble(arr->data[index]);
+  HPy item = HPyFloat_FromDouble(ctx, arr->data[index]);
   return item;
 };
 
@@ -159,13 +161,13 @@ static PyType_Slot Array_type_slots[] = {
     {Py_tp_methods, Array_methods},
     {Py_nb_true_divide, (binaryfunc)Array_divide},
     {Py_sq_length, (lenfunc)Array_length},
-    {Py_sq_item, (ssizeargfunc)Array_item},
     {0, NULL},
 };
 
 static HPyDef *Array_defines[] = {
     &Array_add,
     &Array_multiply,
+    &Array_item,
     NULL
 };
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -202,7 +202,6 @@ static HPy init__piconumpy_hpy_impl(HPyContext ctx) {
 
   PyObject *m = HPy_AsPyObject(ctx, hm);
   ptr_ArrayType = (PyTypeObject *)PyType_FromSpec(&Array_type_spec);
-  Py_INCREF(ptr_ArrayType);
   if (PyModule_AddObject(m, "array", (PyObject *)ptr_ArrayType) < 0) {
     Py_DECREF(ptr_ArrayType);
     Py_DECREF(m);

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -20,16 +20,20 @@ static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
   ArrayObject *self = HPy_CAST(ctx, ArrayObject, h_self);
   int index;
   HPy h_data = HPy_NULL;
+  HPyTracker ht;
 
-  if (!HPyArg_ParseKeywords(ctx, args, nargs, kw, "|O", kwlist, &h_data))
-    return -1;
+  if (!HPyArg_ParseKeywords(ctx, &ht, args, nargs, kw, "|O", kwlist, &h_data)) {
+      return -1;
+  }
 
   if (!HPyList_Check(ctx, h_data)) {
+    HPyTracker_Close(ctx, ht);
     HPyErr_SetString(ctx, ctx->h_TypeError, "parameter must be a list");
     return -1;
   }
 
   self->size = (int)HPy_Length(ctx, h_data);
+  HPyTracker_Close(ctx, ht); // done with h_data
 
   self->data = (double *)malloc(self->size * sizeof(double));
   if (self->data == NULL) {

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -11,9 +11,10 @@ typedef struct {
   int size;
 } ArrayObject;
 
-static void Array_dealloc(ArrayObject *self) {
+HPyDef_SLOT(Array_destroy, HPy_tp_destroy, Array_destroy_impl, HPyFunc_DESTROYFUNC)
+static void Array_destroy_impl(void *obj) {
+  ArrayObject *self = (ArrayObject *)obj;
   free(self->data);
-  Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 HPyDef_SLOT(Array_init, HPy_tp_init, Array_init_impl, HPyFunc_INITPROC)
@@ -163,7 +164,6 @@ static PyMethodDef Array_methods[] = {
 HPyDef_SLOT(Array_new, HPy_tp_new, HPyType_GenericNew, HPyFunc_KEYWORDS)
 
 static PyType_Slot Array_type_slots[] = {
-    {Py_tp_dealloc, (destructor)Array_dealloc},
     {Py_tp_members, Array_members},
     {Py_tp_methods, Array_methods},
     {0, NULL},
@@ -172,6 +172,7 @@ static PyType_Slot Array_type_slots[] = {
 static HPyDef *Array_defines[] = {
     &Array_new,
     &Array_init,
+    &Array_destroy,
     &Array_add,
     &Array_multiply,
     &Array_divide,

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -131,8 +131,11 @@ static ArrayObject *Array_divide(PyObject *o1, PyObject *o2) {
   return result;
 };
 
-Py_ssize_t Array_length(ArrayObject *arr) {
-  Py_ssize_t result = (Py_ssize_t)arr->size;
+
+HPyDef_SLOT(Array_length, HPy_sq_length, Array_length_impl, HPyFunc_LENFUNC)
+HPy_ssize_t Array_length_impl(HPyContext ctx, HPy h_arr) {
+  ArrayObject *arr = HPy_CAST(ctx, ArrayObject, h_arr);
+  HPy_ssize_t result = (HPy_ssize_t)arr->size;
   return result;
 };
 
@@ -160,7 +163,6 @@ static PyType_Slot Array_type_slots[] = {
     {Py_tp_members, Array_members},
     {Py_tp_methods, Array_methods},
     {Py_nb_true_divide, (binaryfunc)Array_divide},
-    {Py_sq_length, (lenfunc)Array_length},
     {0, NULL},
 };
 
@@ -168,6 +170,7 @@ static HPyDef *Array_defines[] = {
     &Array_add,
     &Array_multiply,
     &Array_item,
+    &Array_length,
     NULL
 };
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -62,13 +62,13 @@ HPyDef_METH(Array_tolist, "tolist", Array_tolist_impl, HPyFunc_NOARGS)
 static HPy Array_tolist_impl(HPyContext ctx, HPy h_self) {
   ArrayObject *self = HPy_CAST(ctx, ArrayObject, h_self);
   int index;
-  HPy h_result = HPyList_New(ctx, self->size);
+  HPyListBuilder builder = HPyListBuilder_New(ctx, self->size);
   for (index = 0; index < self->size; index++) {
     HPy h_item = HPyFloat_FromDouble(ctx, self->data[index]);
-    HPy_SetItem_i(ctx, h_result, index, h_item);
+    HPyListBuilder_Set(ctx, builder, index, h_item);
     HPy_Close(ctx, h_item);
   }
-  return h_result;
+  return HPyListBuilder_Build(ctx, builder);
 };
 
 static HPy Array_empty(HPyContext ctx, int size, ArrayObject **result);

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -33,10 +33,10 @@ static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
   }
 
   self->size = (int)HPy_Length(ctx, h_data);
-  HPyTracker_Close(ctx, ht); // done with h_data
 
   self->data = (double *)malloc(self->size * sizeof(double));
   if (self->data == NULL) {
+    HPyTracker_Close(ctx, ht); // done with h_data
     HPyErr_NoMemory(ctx);
     return -1;
   }
@@ -49,6 +49,7 @@ static int Array_init_impl(HPyContext ctx, HPy h_self, HPy *args,
     HPy_Close(ctx, h_item);
   }
 
+  HPyTracker_Close(ctx, ht); // done with h_data
   return 0;
 }
 

--- a/piconumpy/purepy.py
+++ b/piconumpy/purepy.py
@@ -30,3 +30,7 @@ class array:
 
 def empty(size):
     return array([0]*size)
+
+def zeros(size):
+    return array([0]*size)
+

--- a/piconumpy/purepy.py
+++ b/piconumpy/purepy.py
@@ -27,6 +27,8 @@ class array:
     def __getitem__(self, index):
         return self.data[index]
 
+    def __setitem__(self, index, value):
+        self.data[index] = value
 
 def empty(size):
     return array([0]*size)

--- a/piconumpy/purepy.py
+++ b/piconumpy/purepy.py
@@ -26,3 +26,7 @@ class array:
 
     def __getitem__(self, index):
         return self.data[index]
+
+
+def empty(size):
+    return array([0]*size)

--- a/piconumpy/purepy_array.py
+++ b/piconumpy/purepy_array.py
@@ -22,3 +22,6 @@ class array(_array.array):
 
     def __truediv__(self, other):
         return self.__class__(number / other for number in self)
+
+def empty(size):
+    return array([0]*size)

--- a/piconumpy/purepy_array.py
+++ b/piconumpy/purepy_array.py
@@ -25,3 +25,6 @@ class array(_array.array):
 
 def empty(size):
     return array([0]*size)
+
+def zeros(size):
+    return array([0]*size)

--- a/piconumpy/test_cpython_capi.py
+++ b/piconumpy/test_cpython_capi.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 from . import _piconumpy_cpython_capi
@@ -22,6 +23,20 @@ class Tests:
     def test_init_array(self):
         a = self._array([1.0, 2.0])
         assert a.size == 2
+
+    def test_getitem_setitem(self):
+        a = self._array([12.0, 34.0])
+        assert a[0] == 12.0
+        assert a[1] == 34.0
+        a[0] = 56
+        a[1] = 78
+        assert a[0] == 56.0
+        assert a[1] == 78.0
+        #
+        with pytest.raises(IndexError):
+            a[2]
+        with pytest.raises(IndexError):
+            a[2] = 3
 
     def test_init_array_numpy(self):
         np_a = np.array([1.0, 2.0, 0.0, 0.0])

--- a/piconumpy/test_cpython_capi.py
+++ b/piconumpy/test_cpython_capi.py
@@ -13,6 +13,12 @@ class Tests:
         assert type(a) is self.piconumpy.array
         assert a.size == 12
 
+    def test_zeros(self):
+        a = self.piconumpy.zeros(5)
+        assert type(a) is self.piconumpy.array
+        assert a.size == 5
+        assert a.tolist() == [0, 0, 0, 0, 0]
+
     def test_init_array(self):
         a = self._array([1.0, 2.0])
         assert a.size == 2

--- a/piconumpy/test_cpython_capi.py
+++ b/piconumpy/test_cpython_capi.py
@@ -1,10 +1,17 @@
 import numpy as np
 
-from . import array
+from . import _piconumpy_cpython_capi
 
 
 class Tests:
-    _array = array
+    piconumpy = _piconumpy_cpython_capi
+    def _array(self, *args):
+        return self.piconumpy.array(*args)
+
+    def test_empty(self):
+        a = self.piconumpy.empty(12)
+        assert type(a) is self.piconumpy.array
+        assert a.size == 12
 
     def test_init_array(self):
         a = self._array([1.0, 2.0])

--- a/piconumpy/test_cython.py
+++ b/piconumpy/test_cython.py
@@ -1,4 +1,4 @@
 from .test_cpython_capi import Tests as _Tests
 
 class Tests(_Tests):
-    import _piconumpy_cython as piconumpy
+    from . import _piconumpy_cython as piconumpy

--- a/piconumpy/test_cython.py
+++ b/piconumpy/test_cython.py
@@ -1,6 +1,4 @@
-from ._piconumpy_cython import array
 from .test_cpython_capi import Tests as _Tests
 
-
 class Tests(_Tests):
-    _array = array
+    import _piconumpy_cython as piconumpy

--- a/piconumpy/test_hpy.py
+++ b/piconumpy/test_hpy.py
@@ -1,0 +1,6 @@
+from ._piconumpy_hpy import array
+from .test_cpython_capi import Tests as _Tests
+
+
+class Tests(_Tests):
+    _array = array

--- a/piconumpy/test_hpy.py
+++ b/piconumpy/test_hpy.py
@@ -1,4 +1,4 @@
 from .test_cpython_capi import Tests as _Tests
 
 class Tests(_Tests):
-    import _piconumpy_hpy as piconumpy
+    from . import _piconumpy_hpy as piconumpy

--- a/piconumpy/test_hpy.py
+++ b/piconumpy/test_hpy.py
@@ -1,6 +1,4 @@
-from ._piconumpy_hpy import array
 from .test_cpython_capi import Tests as _Tests
 
-
 class Tests(_Tests):
-    _array = array
+    import _piconumpy_hpy as piconumpy

--- a/piconumpy/test_purepy.py
+++ b/piconumpy/test_purepy.py
@@ -1,6 +1,4 @@
-from .purepy import array
 from .test_cpython_capi import Tests as _Tests
 
-
 class Tests(_Tests):
-    _array = array
+    from . import purepy as piconumpy

--- a/piconumpy/test_purepy_array.py
+++ b/piconumpy/test_purepy_array.py
@@ -1,6 +1,4 @@
-from .purepy_array import array
 from .test_cpython_capi import Tests as _Tests
 
-
 class Tests(_Tests):
-    _array = array
+    from . import purepy_array as piconumpy

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         # black can't be installed with PyPy3!
         "full": ["black"],
     },
-    setup_requires=['hpy.devel'],
+    # you need to manually install hpy.devel from the git repo for now
+    setup_requires=['hpy.devel>0.0'],
     ext_modules=[
         Extension(
             "piconumpy._piconumpy_cpython_capi",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages, Extension
-
+import hpy.devel
 from Cython.Build import cythonize
 
 setup(
@@ -17,7 +17,8 @@ setup(
         ),
         Extension(
             "piconumpy._piconumpy_hpy",
-            ["piconumpy/_piconumpy_hpy.c"],
+            ["piconumpy/_piconumpy_hpy.c"] + hpy.devel.get_sources(),
+            include_dirs=[hpy.devel.get_include()],
         ),
         *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ setup(
             "piconumpy._piconumpy_cpython_capi",
             ["piconumpy/_piconumpy_cpython_capi.c"],
         ),
+        Extension(
+            "piconumpy._piconumpy_hpy",
+            ["piconumpy/_piconumpy_hpy.c"],
+        ),
         *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages, Extension
-import hpy.devel
 from Cython.Build import cythonize
 
 setup(
@@ -10,6 +9,7 @@ setup(
         # black can't be installed with PyPy3!
         "full": ["black"],
     },
+    setup_requires=['hpy.devel'],
     ext_modules=[
         Extension(
             "piconumpy._piconumpy_cpython_capi",
@@ -19,15 +19,16 @@ setup(
                 '-Werror',           # turn warnings into errors (all, for now)
             ]
         ),
-        Extension(
-            "piconumpy._piconumpy_hpy",
-            ["piconumpy/_piconumpy_hpy.c"] + hpy.devel.get_sources(),
-            include_dirs=[hpy.devel.get_include()],
-            extra_compile_args = [
-                '-Wfatal-errors',    # stop after one error (unrelated to warnings)
-                '-Werror',           # turn warnings into errors (all, for now)
-            ]
-        ),
         *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],
+    hpy_ext_modules=[
+        Extension(
+            "piconumpy._piconumpy_hpy",
+            ["piconumpy/_piconumpy_hpy.c"],
+            extra_compile_args = [
+                '-Wfatal-errors',
+                '-Werror',
+            ],
+        ),
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages, Extension
-from Cython.Build import cythonize
+#from Cython.Build import cythonize
 
 setup(
     name="piconumpy",
@@ -19,7 +19,7 @@ setup(
                 '-Werror',           # turn warnings into errors (all, for now)
             ]
         ),
-        *cythonize("piconumpy/_piconumpy_cython.pyx"),
+#        *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],
     hpy_ext_modules=[
         Extension(

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ setup(
             "piconumpy._piconumpy_hpy",
             ["piconumpy/_piconumpy_hpy.c"] + hpy.devel.get_sources(),
             include_dirs=[hpy.devel.get_include()],
+            extra_compile_args = [
+                '-Wfatal-errors',    # stop after one error (unrelated to warnings)
+                '-Werror',           # turn warnings into errors (all, for now)
+            ]
         ),
         *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setup(
         Extension(
             "piconumpy._piconumpy_cpython_capi",
             ["piconumpy/_piconumpy_cpython_capi.c"],
+            extra_compile_args = [
+                '-Wfatal-errors',    # stop after one error (unrelated to warnings)
+                '-Werror',           # turn warnings into errors (all, for now)
+            ]
         ),
         *cythonize("piconumpy/_piconumpy_cython.pyx"),
     ],


### PR DESCRIPTION
Notably this update:

* Removes HPyObject_HEAD.
* Makes use of `HPyType_HELPERS` to define `ArrayObject_AsStruct`.
* Uses `HPyHelpers_AddType` to create the type and add it to the module.
* Changes `HPyContext ctx` to `HPyContex *ctx`.